### PR TITLE
fixes duplicate 'MIME-Version' email header

### DIFF
--- a/new-user-approve.php
+++ b/new-user-approve.php
@@ -489,7 +489,6 @@ class pw_new_user_approve {
         $from_name = get_option( 'blogname' );
 
         $headers = array(
-            "MIME-Version: 1.0\n",
             "From: \"{$from_name}\" <{$admin_email}>\n",
             "Content-Type: text/plain; charset=\"" . get_option( 'blog_charset' ) . "\"\n",
         );


### PR DESCRIPTION
wp-includes/class-phpmailer.php already adds this header. When present here results in duplicate which can be filtered by email server as having bad header (duplicate header). On many email servers messages with bad headers are dropped.
