### PR TITLE
Fix how deny_user() gets user_email

### DIFF
--- a/new-user-approve.php
+++ b/new-user-approve.php
@@ -538,7 +538,7 @@ class pw_new_user_approve {
 		$user = new WP_User( $user_id );
 
 		// send email to user telling of denial
-		$user_email = stripslashes( $user->user_email );
+		$user_email = stripslashes( $user->data->user_email );
 
 		// format the message
 		$message = nua_default_deny_user_message();


### PR DESCRIPTION
change
$user_email = stripslashes( $user->user_email );
to
$user_email = stripslashes( $user->data->user_email );

Encountered this problem when trying to add {username} in my deny email.
