### PR TITLE
add text-domain to header to be able to use wordpress.org translations

### DIFF
--- a/new-user-approve.php
+++ b/new-user-approve.php
@@ -6,6 +6,7 @@
  Author: Josh Harrison
  Version: 1.7.4
  Author URI: http://picklewagon.com/
+ Text Domain: new-user-approve
  */
 
 class pw_new_user_approve {


### PR DESCRIPTION
i'd like to update the dutch translation, and this would be easiest through translate.wordpress.org

the plugin is ready to be translated, since it's using a proper text-domain, but it needs a header to be detected by the automatic process.