### PR TITLE
WooCommerce registration support

### DIFF
--- a/includes/plugins.php
+++ b/includes/plugins.php
@@ -15,3 +15,20 @@ function nua_c2member_dismiss_membership_notice( $show_notice ) {
 	return $show_notice;
 }
 add_filter( 'new_user_approve_show_membership_notice', 'nua_c2member_dismiss_membership_notice' );
+
+/**
+ * Log the user out if they register a new account
+ * with the WooCommerce registration page.
+ */
+function nua_woocommerce_new_user_autologout() {
+	if ( is_user_logged_in() ) {
+		$user_status = pw_new_user_approve()->get_user_status( get_current_user_id() );
+
+		if ( $user_status === 'pending' ){
+			wp_logout();
+
+			return wc_get_page_permalink( 'myaccount' );
+		}
+	}
+}
+add_filter( 'woocommerce_registration_redirect', 'nua_woocommerce_new_user_autologout' );

--- a/new-user-approve.php
+++ b/new-user-approve.php
@@ -85,6 +85,7 @@ class pw_new_user_approve {
 	private function includes() {
 		require_once( $this->get_plugin_dir() . 'includes/email-tags.php' );
 		require_once( $this->get_plugin_dir() . 'includes/messages.php' );
+		require_once( $this->get_plugin_dir() . 'includes/plugins.php' );
 	}
 
 	/**


### PR DESCRIPTION
If the user creates an account from a WooCommerce registration page, they get automatically logged out instead of staying logged in.