### PR TITLE
Fix lost password Notice Error

### DIFF
--- a/new-user-approve.php
+++ b/new-user-approve.php
@@ -684,7 +684,7 @@ class pw_new_user_approve {
 			$user_data = get_user_by( 'email', $email );
 		}
 
-		if ( $user_data->pw_user_status && $user_data->pw_user_status != 'approved' ) {
+		if ( $user_data && $user_data->pw_user_status && $user_data->pw_user_status != 'approved' ) {
 			$errors->add( 'unapproved_user', __( '<strong>ERROR</strong>: User has not been approved.', 'new-user-approve' ) );
 		}
 


### PR DESCRIPTION
Hi,

* WordPress 4.9.1
* This plugin version : latest as of now

There might be a chance that `$user_data` is null, in such cases there will a notice error.
I have fixed by adding an additional check.

https://github.com/picklewagon/new-user-approve/blob/ea615a3634df638a6c53ad5461e39b0e102e09fd/new-user-approve.php#L687

Thanks.